### PR TITLE
Reimplementation of the ORA special remote

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -200,10 +200,11 @@ for:
           export TMPDIR=/crippledfs
         fi
       - echo TMPDIR=$TMPDIR
-      # run tests on installed module, not source tree files
       - mkdir __testhome__
-      - cd __testhome__
-      - python -m pytest -s -v -m "not (turtle)" --doctest-modules --cov=datalad_ria --pyargs ${DTS}
+      # run tests on installed module, not source tree files
+      - |
+        cd __testhome__
+        python -m pytest -s -v -m "not (turtle)" --doctest-modules --cov=datalad_ria --cov-config=../.coveragerc --pyargs ${DTS}
       # restiore original TMPDIR
       - export TMPDIR=$PREV_TMPDIR
 
@@ -268,7 +269,7 @@ for:
       # run tests on installed module, not source tree files
       - cmd: md __testhome__
       - cmd: cd __testhome__
-      - cmd: python -m pytest -s -v -m "not (turtle)" --doctest-modules --cov=datalad_ria --pyargs %DTS%
+      - cmd: python -m pytest -s -v -m "not (turtle)" --doctest-modules --cov=datalad_ria --cov-config=..\.coveragerc --pyargs %DTS%
 
     after_test:
       - python -m coverage xml

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,11 @@
+[run]
+parallel = True
+branch = True
+data_file = ${COVERAGE_ROOT-.}/.coverage
+omit =
+  # versioneer
+  */_version.py
+
+[report]
+# show lines missing coverage in output
+show_missing = True

--- a/datalad_ria/ora_remote.py
+++ b/datalad_ria/ora_remote.py
@@ -1,0 +1,103 @@
+import logging
+from datalad_next.annexremotes import (
+    RemoteError,
+    SpecialRemote,
+    super_main
+)
+
+lgr = logging.getLogger('datalad.customremotes.ora_remote')
+
+
+class RemoteCommandFailedError(Exception):
+    pass
+
+
+class RIARemoteError(RemoteError):
+    pass
+
+
+class OraRemote(SpecialRemote):
+    """
+    git-annex special remote 'ORA' for storing and obtaining files in and from
+    RIA stores.
+
+    It is a reimplementation of an earlier ORA remote (until 0.19.x a part of
+    the DataLad core library).
+
+
+    Configuration
+    -------------
+
+    The behavior of this special remote can be tuned via a number of
+    configuration settings.
+
+    `datalad.ora.legacy-mode=yes|[no]`
+      If enabled, all special remote operations fall back onto the
+      legacy ``ORA`` special remote implementation. This mode is
+      only provided for backward-compatibility.
+    """
+    def __init__(self, annex):
+        super().__init__(annex)
+        # the following members will be initialized on prepare()
+        # as they require access to the underlying repository
+        self._repo = None
+        # name of the special remote
+        self._remotename = None
+        # name of the corresponding Git remote
+        self._gitremotename = None
+        self.archive_id = None
+        self._legacy_special_remote = None
+        self.remote_dataset_tree_version = None
+        self.remote_object_tree_version = None
+
+    def initremote(self):
+        if not self.archive_id:
+            # The config manager can handle bare repos since datalad#6332
+            self.archive_id = self._repo.config.get('datalad.dataset.id')
+        pass
+
+    def prepare(self):
+        # determine if we are in legacy mode, and if so, fall back to legacy ORA
+        if self.get_remote_gitcfg(
+                'ora', 'legacy-mode', default='no').lower() == 'yes':
+            # ATTENTION DEBUGGERS!
+            # If we get here, we will bypass all the ora implementation!
+            # Check __getattribute__() -- pretty much no other code in this
+            # file will run! __getattribute__ will relay all top-level
+            # operations to an instance of the legacy implementation
+            from datalad.distributed.ora_remote import ORARemote as LegacyORARemote
+            lsr = LegacyORARemote(self.annex)
+            lsr.prepare()
+            # we can skip everything else, it won't be triggered anymore
+            self._legacy_special_remote = lsr
+        pass
+
+    def transfer_store(self, key, filename):
+        pass
+
+    def transfer_retrieve(self, key, filename):
+        pass
+
+    def checkpresent(self, key):
+        pass
+
+    def remove(self, key):
+        pass
+
+    def getcost(self):
+        pass
+
+    def whereis(self, key):
+        pass
+
+    def checkurl(self, url):
+        pass
+
+    def claimurl(self, url):
+        pass
+
+    def getavailability(self):
+        pass
+
+    def getinfo(self):
+        pass

--- a/datalad_ria/tests/test_ora.py
+++ b/datalad_ria/tests/test_ora.py
@@ -51,3 +51,20 @@ def test_ora_localops(ria_store_localaccess, populated_dataset):
 
     # smoke test that it can run
     repo.call_annex(ir_cmd + [f'url=ria+{store_path.as_uri()}'])
+
+    cp_cmd = [
+        'copy',
+        '-t', f'test-{ora_external_type}',
+    ]
+
+    repo.call_annex(cp_cmd + ['one.txt'])
+    # the annex key properties (and dirhash) are determined by the
+    # file content and the MD5E backend default.
+    # If neither of those changes, they must not change
+    key_fpath = store_path / \
+        ds.id[:3] / ds.id[3:] / 'annex' / 'objects' / \
+        'X9' / '6J' / \
+        'MD5E-s8--7e55db001d319a94b0b713529a756623.txt' / \
+        'MD5E-s8--7e55db001d319a94b0b713529a756623.txt'
+    assert key_fpath.exists()
+    assert key_fpath.read_text() == 'content1'

--- a/datalad_ria/tests/test_ora.py
+++ b/datalad_ria/tests/test_ora.py
@@ -1,0 +1,38 @@
+import pytest
+import re
+
+from datalad_next.runners import (
+    CommandError,
+)
+
+# we may witch this to just 'ora', once we have feature parity
+ora_external_type = 'ora2'
+
+
+def test_ora_initremote_errors(ria_store_localaccess, existing_dataset):
+    ds = existing_dataset
+    repo = ds.repo
+    _, store_path = ria_store_localaccess
+
+    ir_cmd = [
+        'initremote',
+        f'test-{ora_external_type}',
+        'type=external',
+        f'externaltype={ora_external_type}',
+        'encryption=none',
+    ]
+
+    with pytest.raises(
+        CommandError,
+        match='Specify a RIA store URL with url=',
+    ):
+        repo.call_annex(ir_cmd)
+    with pytest.raises(
+        CommandError,
+        match=re.escape('ria+<scheme>://... URL expected for url='),
+    ):
+        # use a file:// url here
+        repo.call_annex(ir_cmd + [f'url={store_path.as_uri()}'])
+
+    # smoke test that it can run
+    repo.call_annex(ir_cmd + [f'url=ria+{store_path.as_uri()}'])

--- a/datalad_ria/tests/test_ora.py
+++ b/datalad_ria/tests/test_ora.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 import pytest
 import re
 
@@ -9,10 +10,10 @@ from datalad_next.runners import (
 ora_external_type = 'ora2'
 
 
-def test_ora_initremote_errors(ria_store_localaccess, existing_dataset):
+def test_ora_initremote_errors(existing_dataset):
     ds = existing_dataset
     repo = ds.repo
-    _, store_path = ria_store_localaccess
+    store_path = Path.cwd()
 
     ir_cmd = [
         'initremote',
@@ -33,6 +34,20 @@ def test_ora_initremote_errors(ria_store_localaccess, existing_dataset):
     ):
         # use a file:// url here
         repo.call_annex(ir_cmd + [f'url={store_path.as_uri()}'])
+
+
+def test_ora_localops(ria_store_localaccess, populated_dataset):
+    ds = populated_dataset
+    repo = ds.repo
+    _, store_path = ria_store_localaccess
+
+    ir_cmd = [
+        'initremote',
+        f'test-{ora_external_type}',
+        'type=external',
+        f'externaltype={ora_external_type}',
+        'encryption=none',
+    ]
 
     # smoke test that it can run
     repo.call_annex(ir_cmd + [f'url=ria+{store_path.as_uri()}'])

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,6 +41,8 @@ datalad.extensions =
     # the entrypoint can point to any symbol of any name, as long it is
     # valid datalad interface specification (see demo in this extensions)
     ria = datalad_ria:command_suite
+console_scripts =
+    git-annex-remote-ora2 = datalad_ria.ora_remote:main
 
 [versioneer]
 # See the docstring in versioneer.py for instructions. Note that you must


### PR DESCRIPTION
I suspect that a useful first step towards the re-implementation of RIA functionality is a new and improved ORA remote. This PR wants to do this. At the moment, its minimal first commits are pushed to invite comments and collaboration. 

No design decisions have been made other than to base it on datalad-next's SpecialRemote base class.