### PR TITLE
New ria_sshserver fixture

### DIFF
--- a/datalad_ria/tests/fixtures.py
+++ b/datalad_ria/tests/fixtures.py
@@ -5,38 +5,14 @@ import getpass
 import os
 from pathlib import Path
 import pytest
-import subprocess
 
 from datalad_next.tests.utils import (
     SkipTest,
 )
 
-
-def verify_ssh_access(host, port, login, seckey, path, localpath):
-    # we can only handle openssh
-    ssh_bin = os.environ.get('DATALAD_SSH_EXECUTABLE', 'ssh')
-
-    ssh_call = [
-        ssh_bin,
-        '-i', seckey,
-        '-p', port,
-        f'{login}@{host}',
-    ]
-    # now try if this is a viable configuration
-    # verify execute and write permissions (implicitly also POSIX path handling
-    subprocess.run(
-        ssh_call + [f"bash -c 'mkdir -p {path} && touch {path}/datalad-tests-probe'"],
-        check=True,
-    )
-    if localpath:
-        # check if a given
-        assert (Path(localpath) / 'datalad-tests-probe').exists()
-    subprocess.run(
-        ssh_call + [f"bash -c 'rm {path}/datalad-tests-probe'"],
-        check=True,
-    )
-    if localpath:
-        assert not (Path(localpath) / 'datalad-tests-probe').exists()
+from datalad_ria.tests.utils import (
+    assert_ssh_access,
+)
 
 
 @pytest.fixture(autouse=False, scope="session")
@@ -61,7 +37,7 @@ def ria_sshserver(tmp_path_factory):
     path = os.environ.get('DATALAD_TESTS_RIA_SERVER_SSH_PATH', tmp_riaroot)
     localpath = os.environ.get('DATALAD_TESTS_RIA_SERVER_LOCALPATH', tmp_riaroot)
 
-    verify_ssh_access(host, port, login, seckey, path, localpath)
+    assert_ssh_access(host, port, login, seckey, path, localpath)
 
     info = {}
     # as far as we can tell, this is good, post effective config in ENV

--- a/datalad_ria/tests/test_fixtures.py
+++ b/datalad_ria/tests/test_fixtures.py
@@ -1,14 +1,24 @@
-from .utils import assert_ssh_access
+from datalad_ria.tests.utils import assert_ssh_access
+
+# we import this one, rather than putting it into conftest.py, because
+# it is considered internal, in contrast to `ria_sshserver`
+from datalad_ria.tests.fixtures import ria_sshserver_setup
 
 
-def test_riaserver_fixture(ria_sshserver):
+def test_riaserver_setup_fixture(ria_sshserver_setup):
     # we run the same test that the fixture already ran, to verify that
     # the necessary information comes out of the fixture in a usable manner
     assert_ssh_access(
-        ria_sshserver['HOST'],
-        ria_sshserver['SSH_PORT'],
-        ria_sshserver['SSH_LOGIN'],
-        ria_sshserver['SSH_SECKEY'],
-        ria_sshserver['SSH_PATH'],
-        ria_sshserver['LOCALPATH'],
+        ria_sshserver_setup['HOST'],
+        ria_sshserver_setup['SSH_PORT'],
+        ria_sshserver_setup['SSH_LOGIN'],
+        ria_sshserver_setup['SSH_SECKEY'],
+        ria_sshserver_setup['SSH_PATH'],
+        ria_sshserver_setup['LOCALPATH'],
     )
+
+
+def test_riaserver_fixture(ria_sshserver):
+    # base url and local path
+    assert len(ria_sshserver) == 2
+    assert ria_sshserver[0].startswith('ria+ssh://')

--- a/datalad_ria/tests/test_fixtures.py
+++ b/datalad_ria/tests/test_fixtures.py
@@ -1,10 +1,10 @@
-from .fixtures import verify_ssh_access
+from .utils import assert_ssh_access
 
 
 def test_riaserver_fixture(ria_sshserver):
     # we run the same test that the fixture already ran, to verify that
     # the necessary information comes out of the fixture in a usable manner
-    verify_ssh_access(
+    assert_ssh_access(
         ria_sshserver['HOST'],
         ria_sshserver['SSH_PORT'],
         ria_sshserver['SSH_LOGIN'],

--- a/datalad_ria/tests/utils.py
+++ b/datalad_ria/tests/utils.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+
+import os
+from pathlib import Path
+import subprocess
+
+
+def assert_ssh_access(
+    host: str,
+    port: str,
+    login: str,
+    seckey: str,
+    path: str,
+    localpath: str | None = None,
+):
+    """Test for a working SSH connection and sufficient permissions to write
+
+    This helper establishes a connection to an SSH server identified by
+    ``host`` and ``port``, using a given SSH private key file (``seckey``) for
+    authentication.  Once logged in successfully, it tries to create a
+    directory and a file at POSIX ``path`` on the server. If ``localpath`` is
+    given, it must be a representation of that server-side path on the local
+    file system (e.g., a bindmount), and the helper tests whether the created
+    content is also reflected in this directory.
+    """
+    # we can only handle openssh
+    ssh_bin = os.environ.get('DATALAD_SSH_EXECUTABLE', 'ssh')
+
+    ssh_call = [
+        ssh_bin,
+        '-i', seckey,
+        '-p', port,
+        f'{login}@{host}',
+    ]
+    # now try if this is a viable configuration
+    # verify execute and write permissions (implicitly also POSIX path handling
+    subprocess.run(
+        ssh_call + [
+            f"bash -c 'mkdir -p {path} && touch {path}/datalad-tests-probe'"],
+        check=True,
+    )
+    if localpath:
+        # check if a given
+        assert (Path(localpath) / 'datalad-tests-probe').exists()
+    subprocess.run(
+        ssh_call + [f"bash -c 'rm {path}/datalad-tests-probe'"],
+        check=True,
+    )
+    if localpath:
+        assert not (Path(localpath) / 'datalad-tests-probe').exists()

--- a/datalad_ria/utils.py
+++ b/datalad_ria/utils.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+
+def build_ria_url(
+    protocol: str,
+    host: str,
+    port: str | None = None,
+    path: str | None = None,
+    user: str | None = None,
+    passwd: str | None = None,
+
+):
+    if passwd and (user is None):
+        raise ValueError('password without user name given')
+
+    url = (
+        'ria+{protocol}://{user}{passdlm}{passwd}{userdlm}'
+        '{host}{portdlm}{port}{pathdlm}{path}'
+    ).format(
+        protocol=protocol,
+        user=user or '',
+        passdlm=':' if passwd else '',
+        passwd=passwd or '',
+        userdlm='@' if user else '',
+        host=host or '',
+        portdlm=':' if port else '',
+        port=port or '',
+        pathdlm='/' if path and not path.startswith('/') else '',
+        path=path or '',
+    )
+    return url


### PR DESCRIPTION
This should be easier to use. The old implementation is now available in
`ria_sshserver_setup` and should be considered internal.

The new fixture returns the base RIA URL, and a local path to that same
root directory (if one exists).

It also sets `DATALAD_SSH_IDENTITYFILE`, which is needed by datalad-core's `SSHManager`. The setup may still need to use the `datalad_cfg` fixture, and possibly a dedicated reload to be effective.

Closes #60