### PR TITLE
Test the most basic layer of SSH-based code execution 

### DIFF
--- a/datalad_ria/tests/fixtures.py
+++ b/datalad_ria/tests/fixtures.py
@@ -62,7 +62,7 @@ def ria_sshserver_setup(tmp_path_factory):
 
 
 @pytest.fixture(autouse=False, scope="function")
-def ria_sshserver(ria_sshserver_setup, monkeypatch):
+def ria_sshserver(ria_sshserver_setup, datalad_cfg, monkeypatch):
     ria_baseurl = build_ria_url(
         protocol='ssh',
         host=ria_sshserver_setup['HOST'],
@@ -71,6 +71,9 @@ def ria_sshserver(ria_sshserver_setup, monkeypatch):
     )
     with monkeypatch.context() as m:
         m.setenv("DATALAD_SSH_IDENTITYFILE", ria_sshserver_setup['SSH_SECKEY'])
+        # force reload the config manager, to ensure the private key setting
+        # makes it into the active config
+        datalad_cfg.reload(force=True)
         yield ria_baseurl, ria_sshserver_setup['LOCALPATH']
 
 

--- a/datalad_ria/tests/test_ssh_connection.py
+++ b/datalad_ria/tests/test_ssh_connection.py
@@ -1,0 +1,21 @@
+
+from datalad.support.sshconnector import SSHManager as sshman
+
+
+def test_SSHConnection(ria_sshserver_setup, ria_sshserver):
+    # this is the most basic smoke test, login to run a command,
+    # check that it does not fail completely
+    sm = sshman()
+    ssh_url = 'ssh://{SSH_LOGIN}@{HOST}:{SSH_PORT}'.format(
+        **ria_sshserver_setup)
+
+    con = sm.get_connection(ssh_url)
+    out, err = con(
+        'ls /',
+        # this is a workaround to enable proper handling on
+        # windows, see https://github.com/datalad/datalad-ria/issues/68
+        # eventually this should become unnecessary
+        stdin=b'',
+    )
+    assert not err
+    assert out


### PR DESCRIPTION
This included test explains why it is a workaround.

I will merge this, once the tests have passed. This is not saying that we do not need an actual solution. But we should claim this victory to make sure we do not fall below it again.