### PR TITLE
Do not check revocation lists in curl calls

### DIFF
--- a/tools/ci/setup-sshd
+++ b/tools/ci/setup-sshd
@@ -7,7 +7,7 @@ DATALAD_TESTS_RIA_SERVER_SSH_SECKEY=${DATALAD_TESTS_RIA_SERVER_SSH_SECKEY:-$HOME
 
 function setup_docker () {
   # obtain the docker image for SSH testing
-  curl -fsSL -o sshd.dockerimg.gz "${DATALAD_TESTS_DOCKER_SSHD_DOWNLOADURL}"
+  curl -fsSL --ssl-no-revoke -o sshd.dockerimg.gz "${DATALAD_TESTS_DOCKER_SSHD_DOWNLOADURL}"
   gzip -c -d sshd.dockerimg.gz | docker load
 
   # obtain the matching SSH private key for SSH server login

--- a/tools/ci/setup-sshd.bat
+++ b/tools/ci/setup-sshd.bat
@@ -1,7 +1,7 @@
 :: set -x
 @echo on
 :: download and ingest docker image
-curl -fsSL -o sshd.dockerimg.gz %DATALAD_TESTS_DOCKER_SSHD_DOWNLOADURL%
+curl -fsSL --ssl-no-revoke -o sshd.dockerimg.gz %DATALAD_TESTS_DOCKER_SSHD_DOWNLOADURL%
 gzip -c -d sshd.dockerimg.gz | docker load
 :: start container
 docker run --rm -dit --name %DATALAD_TESTS_DOCKER_SSHD_CONTAINER_NAME% -p %DATALAD_TESTS_RIA_SERVER_SSH_PORT%:22 -v %DATALAD_TESTS_RIA_SERVER_LOCALPATH%:%DATALAD_TESTS_RIA_SERVER_SSH_PATH% sshd
@@ -12,6 +12,6 @@ ssh-keygen -f C:\Users\appveyor\.ssh\known_hosts -R "[%DATALAD_TESTS_RIA_SERVER_
 :: ingest actual host key
 ssh-keyscan -t ecdsa -p %DATALAD_TESTS_RIA_SERVER_SSH_PORT% %DATALAD_TESTS_RIA_SERVER_SSH_HOST% >> C:\Users\appveyor\.ssh\known_hosts
 :: get the ssh key matching the container
-curl -fsSL -o %DATALAD_TESTS_RIA_SERVER_SSH_SECKEY% %DATALAD_TESTS_DOCKER_SSHD_SECKEY_DOWNLOADURL%
+curl -fsSL --ssl-no-revoke -o %DATALAD_TESTS_RIA_SERVER_SSH_SECKEY% %DATALAD_TESTS_DOCKER_SSHD_SECKEY_DOWNLOADURL%
 :: establish expected permission setup for SSH key
 tools\ci\chmod600.bat %DATALAD_TESTS_RIA_SERVER_SSH_SECKEY%


### PR DESCRIPTION
This avoids download failures (for the docker images) when a CI worker has issues with expired certificates. We only download from trusted sources (our own), and the drop in security is minor compared to the failing CIs due to unrelated certficate issues.

This patch is extracted from https://github.com/datalad/datalad-ria/pull/69. It is needed independent of that PR.