### PR TITLE
Add dedicated test for `SSHRemoteIO` symlink handling

### DIFF
--- a/datalad_ria/tests/test_ssh_remote_io.py
+++ b/datalad_ria/tests/test_ssh_remote_io.py
@@ -21,11 +21,15 @@ def ssh_remote_wdir(ssh_remoteio, ria_sshserver_setup):
     directory at the end.
     """
     sshpath = PurePosixPath(ria_sshserver_setup['SSH_PATH'])
-    out, err = ssh_remoteio.ssh(f'mktemp -d -p {sshpath}')
+    out, err = ssh_remoteio.ssh(f'mktemp -d {sshpath}/sshremotewdir.XXXXXXXX')
+    # hopefully catch more stupid errors of unexpectedness
+    assert '/sshremotewdir' in out
     wdir = PurePosixPath(out.rstrip('\n'))
     yield ssh_remoteio, wdir
     # clean up
-    ssh_remoteio.ssh(f'echo rm -rf "{wdir}"')
+    # only run dangerous 'rm -rf' if needed
+    if ssh_remoteio.exists(wdir):
+        ssh_remoteio.ssh(f'echo rm -rf "{wdir}"')
 
 
 def test_SSHRemoteIO_read_file(ssh_remoteio):

--- a/datalad_ria/tests/test_ssh_remote_io.py
+++ b/datalad_ria/tests/test_ssh_remote_io.py
@@ -43,3 +43,17 @@ def test_SSHRemoteIO_handledir(ssh_remoteio, ria_sshserver_setup):
     # ssh_remoteio.remove(targetdir)
     ssh_remoteio.remove_dir(targetdir)
     assert not ssh_remoteio.exists(targetdir)
+
+
+def test_SSHRemoteIO_symlink(ssh_remoteio, ria_sshserver_setup):
+    sshpath = PurePosixPath(ria_sshserver_setup['SSH_PATH'])
+    targetdir = sshpath / 'testdir'
+    ssh_remoteio.mkdir(targetdir)
+    targetfpath = targetdir / 'testfile'
+    assert not ssh_remoteio.exists(targetfpath)
+    ssh_remoteio.symlink('/etc/passwd', targetfpath)
+    assert ssh_remoteio.exists(targetfpath)
+    assert ssh_remoteio.read_file('/etc/passwd') \
+        == ssh_remoteio.read_file(targetfpath)
+    ssh_remoteio.remove(targetfpath)
+    assert not ssh_remoteio.exists(targetfpath)


### PR DESCRIPTION
Plus: New `ssh_remote_wdir` to streamline remote working dir provisioning