### PR TITLE
`SSHRemoteIO.remove_dir()` now fails on non-empty directories 

### DIFF
--- a/datalad_ria/patches/sshremoteio.py
+++ b/datalad_ria/patches/sshremoteio.py
@@ -182,15 +182,9 @@ def SSHRemoteIO_run(self, cmd, no_output=True, check=False):
     return "".join(lines)
 
 
-apply_patch(
-    'datalad.distributed.ora_remote', 'SSHRemoteIO', '__init__',
-    SSHRemoteIO__init__,
-)
-apply_patch(
-    'datalad.distributed.ora_remote', 'SSHRemoteIO', '_append_end_markers',
-    SSHRemoteIO_append_end_markers,
-)
-apply_patch(
-    'datalad.distributed.ora_remote', 'SSHRemoteIO', '_run',
-    SSHRemoteIO_run,
-)
+for target, patch in (
+        ('__init__', SSHRemoteIO__init__),
+        ('_append_end_markers', SSHRemoteIO_append_end_markers),
+        ('_run', SSHRemoteIO_run),
+):
+    apply_patch('datalad.distributed.ora_remote', 'SSHRemoteIO', target, patch)

--- a/datalad_ria/tests/test_ssh_remote_io.py
+++ b/datalad_ria/tests/test_ssh_remote_io.py
@@ -1,7 +1,10 @@
 from pathlib import PurePosixPath
 import pytest
 
-from datalad.distributed.ora_remote import SSHRemoteIO
+from datalad.distributed.ora_remote import (
+    RemoteCommandFailedError,
+    SSHRemoteIO,
+)
 
 
 @pytest.fixture(autouse=False, scope="function")
@@ -65,8 +68,8 @@ def test_SSHRemoteIO_handledir(ssh_remoteio, ria_sshserver_setup):
     ssh_remoteio.write_file(targetfpath, 'dummy')
     assert ssh_remoteio.exists(targetfpath)
 
-    # XXX calling remove_dir()has no effect, and causes no error!!!
-    ssh_remoteio.remove_dir(targetdir)
+    with pytest.raises(RemoteCommandFailedError):
+        ssh_remoteio.remove_dir(targetdir)
     assert ssh_remoteio.exists(targetdir)
 
     # we must "know" that there is content and remove it


### PR DESCRIPTION
This aligns its behavior with `FileIO.remove_dir()`.

Closes #82