### PR TITLE
Add fixture create_store_local to set up a store skeleton locally

### DIFF
--- a/datalad_ria/conftest.py
+++ b/datalad_ria/conftest.py
@@ -5,6 +5,7 @@ pytest_plugins = [
 ]
 
 from .tests.fixtures import (
+    create_store_local,
     common_ora_init_opts,
     populated_dataset,
     ria_sshserver,

--- a/datalad_ria/tests/fixtures.py
+++ b/datalad_ria/tests/fixtures.py
@@ -101,3 +101,15 @@ def common_ora_init_opts():
     common_init_opts = ["encryption=none", "type=external", "externaltype=ora",
                         "autoenable=true"]
     yield common_init_opts
+
+
+@pytest.fixture(autouse=False, scope="function")
+def create_store_local(tmp_path):
+    basepath = tmp_path / 'store'
+    error_logs = basepath / 'error_logs'
+    version_file = basepath / 'ria-layout-version'
+    basepath.mkdir()
+    error_logs.touch()
+    version_file.write_text('1')
+    return basepath
+

--- a/datalad_ria/tests/test_fixtures.py
+++ b/datalad_ria/tests/test_fixtures.py
@@ -38,3 +38,8 @@ def test_common_ora_init_opts_fixture(common_ora_init_opts):
     assert "externaltype=ora" in common_ora_init_opts
     assert "autoenable=true" in common_ora_init_opts
 
+
+def test_create_store_local(create_store_local):
+    assert create_store_local.exists()
+    assert (create_store_local / 'error_logs').exists()
+    assert (create_store_local / 'ria-layout-version').read_text() == '1'


### PR DESCRIPTION
This matches what #95 does, but at temporary local paths.