### PR TITLE
Document the challenge to implement RIA store cleanups

### DIFF
--- a/datalad_ria/ora_remote.py
+++ b/datalad_ria/ora_remote.py
@@ -86,6 +86,16 @@ class Ora2Remote(UncurlRemote):
         # the rest is UNCURL "business as usual"
         super().prepare()
 
+    def delete(self, key):
+        # delete the key
+        super().delete(key)
+        # TODO depending on the nature of RIA store, we also should remove
+        # the key directory, and possibly also the dirhash-type parents.
+        # so possibly we need to make up to three additional deletion
+        # requests via the handler. This can be rather slow, unless the
+        # handler is clever (or we can instruct the handler to trigger
+        # all deletions in one go
+
     #
     # helpers
     #

--- a/datalad_ria/tests/test_ora.py
+++ b/datalad_ria/tests/test_ora.py
@@ -68,3 +68,14 @@ def test_ora_localops(ria_store_localaccess, populated_dataset):
         'MD5E-s8--7e55db001d319a94b0b713529a756623.txt'
     assert key_fpath.exists()
     assert key_fpath.read_text() == 'content1'
+
+    rm_cmd = [
+        'drop',
+        '-f', f'test-{ora_external_type}',
+    ]
+
+    repo.call_annex(rm_cmd + ['one.txt'])
+    assert not key_fpath.exists()
+    # TODO the parent directory stays (for now)
+    # https://github.com/datalad/datalad-next/issues/454
+    assert key_fpath.parent.exists()


### PR DESCRIPTION
It is not sufficient to just deal with the most basic key-operations in the ORA remote. At least when we (know the we) are operating with a filesystem on the remote.

We need to figure out, how we want to tackle this. Ideally without making unnecessary assumptions about the particular capabilties of effective URL handlers.